### PR TITLE
Rename name of methods

### DIFF
--- a/src/PrivateApi/Account.php
+++ b/src/PrivateApi/Account.php
@@ -72,6 +72,7 @@ class Account extends KuCoinApi
     }
 
     /**
+     * Get holds
      * @param string $accountId
      * @param array $pagination
      * @return array

--- a/src/PrivateApi/Deposit.php
+++ b/src/PrivateApi/Deposit.php
@@ -43,14 +43,15 @@ class Deposit extends KuCoinApi
     /**
      * Get deposit list
      * @param array $params
+     * @param array $pagination
      * @return array
      * @throws \KuCoin\SDK\Exceptions\BusinessException
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getDeposits(array $params)
+    public function getDeposits(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/deposits', $params);
+        $response = $this->call(Request::METHOD_GET, '/api/v1/deposits', $params + $pagination);
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/Deposit.php
+++ b/src/PrivateApi/Deposit.php
@@ -27,14 +27,14 @@ class Deposit extends KuCoinApi
     }
 
     /**
-     * Get deposit addresses
+     * Get deposit address of currency for deposit
      * @param string $currency
      * @return array
      * @throws \KuCoin\SDK\Exceptions\BusinessException
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getAddresses($currency)
+    public function getAddress($currency)
     {
         $response = $this->call(Request::METHOD_GET, '/api/v1/deposit-addresses', compact('currency'));
         return $response->getApiData();

--- a/src/PrivateApi/Fill.php
+++ b/src/PrivateApi/Fill.php
@@ -13,18 +13,17 @@ use KuCoin\SDK\KuCoinApi;
 class Fill extends KuCoinApi
 {
     /**
-     * Get a list of recent fills
-     * @param string $orderId
-     * @param string $symbolId
+     * Get a list of fills
+     * @param array $params
      * @param array $pagination
      * @return array
      * @throws \KuCoin\SDK\Exceptions\BusinessException
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getList($orderId, $symbolId, array $pagination = [])
+    public function getList(array $params = [], array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/fills', compact('orderId', 'symbolId') + $pagination);
+        $response = $this->call(Request::METHOD_GET, '/api/v1/fills', $params + $pagination);
         return $response->getApiData();
     }
 

--- a/src/PublicApi/Currency.php
+++ b/src/PublicApi/Currency.php
@@ -27,15 +27,15 @@ class Currency extends KuCoinApi
 
     /**
      * Get the details of a currency
-     * @param string $currencyId
+     * @param string $currency
      * @return array
      * @throws \KuCoin\SDK\Exceptions\BusinessException
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getDetail($currencyId)
+    public function getDetail($currency)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/currencies/' . $currencyId);
+        $response = $this->call(Request::METHOD_GET, '/api/v1/currencies/' . $currency);
         return $response->getApiData();
     }
 }

--- a/src/PublicApi/Symbol.php
+++ b/src/PublicApi/Symbol.php
@@ -62,7 +62,7 @@ class Symbol extends KuCoinApi
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getPartOrderBook($symbol, $depth = 20)
+    public function getAggregatedPartOrderBook($symbol, $depth = 20)
     {
         $response = $this->call(Request::METHOD_GET, '/api/v1/market/orderbook/level2_' . intval($depth), compact('symbol'));
         return $response->getApiData();

--- a/src/PublicApi/Symbol.php
+++ b/src/PublicApi/Symbol.php
@@ -56,14 +56,15 @@ class Symbol extends KuCoinApi
     /**
      * Get part order book(aggregated)
      * @param string $symbol
+     * @param int $depth within 20 or 100, default 20.
      * @return array
      * @throws \KuCoin\SDK\Exceptions\BusinessException
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getPartOrderBook($symbol)
+    public function getPartOrderBook($symbol, $depth = 20)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/market/orderbook/level2_100', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, '/api/v1/market/orderbook/level2_' . intval($depth), compact('symbol'));
         return $response->getApiData();
     }
 

--- a/src/PublicApi/Symbol.php
+++ b/src/PublicApi/Symbol.php
@@ -14,14 +14,15 @@ class Symbol extends KuCoinApi
 {
     /**
      * Get a list of symbol
+     * @param string|null $market
      * @return array
-     * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\BusinessException
+     * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getList()
+    public function getList($market = null)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/symbols');
+        $response = $this->call(Request::METHOD_GET, '/api/v1/symbols', compact('market'));
         return $response->getApiData();
     }
 

--- a/src/PublicApi/Symbol.php
+++ b/src/PublicApi/Symbol.php
@@ -113,20 +113,20 @@ class Symbol extends KuCoinApi
     /**
      * Get historic rates
      * @param string $symbol
-     * @param int $begin
-     * @param int $end
+     * @param int $beginAt
+     * @param int $endAt
      * @param string $type
      * @return array
      * @throws \KuCoin\SDK\Exceptions\BusinessException
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function getHistoricRates($symbol, $begin, $end, $type)
+    public function getHistoricRates($symbol, $beginAt, $endAt, $type)
     {
         $response = $this->call(
             Request::METHOD_GET,
             '/api/v1/market/candles',
-            compact('symbol', 'begin', 'end', 'type')
+            compact('symbol', 'beginAt', 'endAt', 'type')
         );
         return $response->getApiData();
     }

--- a/tests/DepositTest.php
+++ b/tests/DepositTest.php
@@ -51,7 +51,7 @@ class DepositTest extends TestCase
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function testGetAddresses(Deposit $api)
+    public function testGetAddress(Deposit $api)
     {
         try {
             $address = $api->getAddress('BTC');

--- a/tests/DepositTest.php
+++ b/tests/DepositTest.php
@@ -20,7 +20,7 @@ class DepositTest extends TestCase
      * @param Auth $auth
      * @return Deposit
      */
-    public function testNewDeposits(Auth $auth)
+    public function testNewDeposit(Auth $auth)
     {
         $api = new Deposit($auth);
         $this->assertInstanceOf(Deposit::class, $api);
@@ -28,7 +28,7 @@ class DepositTest extends TestCase
     }
 
     /**
-     * @depends testNewDeposits
+     * @depends testNewDeposit
      * @param Deposit $api
      * @return array|string
      * @throws \KuCoin\SDK\Exceptions\BusinessException
@@ -44,7 +44,7 @@ class DepositTest extends TestCase
     }
 
     /**
-     * @depends testNewDeposits
+     * @depends testNewDeposit
      * @param Deposit $api
      * @return array|string
      * @throws \KuCoin\SDK\Exceptions\BusinessException
@@ -70,7 +70,7 @@ class DepositTest extends TestCase
     }
 
     /**
-     * @depends testNewDeposits
+     * @depends testNewDeposit
      * @param Deposit $api
      * @return array|string
      * @throws \KuCoin\SDK\Exceptions\BusinessException
@@ -79,12 +79,7 @@ class DepositTest extends TestCase
      */
     public function testGetDeposits(Deposit $api)
     {
-        $params = [
-            'currency'    => 'BTC',
-            'currentPage' => 1,
-            'pageSize'    => 10,
-        ];
-        $data = $api->getDeposits($params);
+        $data = $api->getDeposits(['currency' => 'BTC'], ['currentPage' => 1, 'pageSize' => 10]);
         $this->assertPagination($data);
         foreach ($data['items'] as $item) {
             $this->assertArrayHasKey('address', $item);

--- a/tests/DepositTest.php
+++ b/tests/DepositTest.php
@@ -54,7 +54,7 @@ class DepositTest extends TestCase
     public function testGetAddresses(Deposit $api)
     {
         try {
-            $address = $api->getAddresses('BTC');
+            $address = $api->getAddress('BTC');
             if ($address !== null) {
                 $this->assertInternalType('array', $address);
                 $this->assertArrayHasKey('address', $address);

--- a/tests/FillTest.php
+++ b/tests/FillTest.php
@@ -35,7 +35,7 @@ class FillTest extends TestCase
      */
     public function testGetList(Fill $api)
     {
-        $data = $api->getList('5c1b409c03aa6732f1f89ed3', 'BTC-USDT', ['currentPage' => 1, 'pageSize' => 10]);
+        $data = $api->getList([], ['currentPage' => 1, 'pageSize' => 10]);
         $this->assertPagination($data);
         foreach ($data['items'] as $item) {
             $this->assertArrayHasKey('symbol', $item);

--- a/tests/SymbolTest.php
+++ b/tests/SymbolTest.php
@@ -25,7 +25,7 @@ class SymbolTest extends TestCase
      */
     public function testGetList(Symbol $api)
     {
-        $data = $api->getList();
+        $data = $api->getList('BTC');
         $this->assertInternalType('array', $data);
         foreach ($data as $item) {
             $this->assertArrayHasKey('quoteCurrency', $item);

--- a/tests/SymbolTest.php
+++ b/tests/SymbolTest.php
@@ -96,9 +96,9 @@ class SymbolTest extends TestCase
      * @throws \KuCoin\SDK\Exceptions\HttpException
      * @throws \KuCoin\SDK\Exceptions\InvalidApiUriException
      */
-    public function testGetPartOrderBook(Symbol $api)
+    public function testGetAggregatedPartOrderBook(Symbol $api)
     {
-        $data = $api->getPartOrderBook('ETH-BTC', 100);
+        $data = $api->getAggregatedPartOrderBook('ETH-BTC', 100);
         $this->assertInternalType('array', $data);
         $this->assertArrayHasKey('sequence', $data);
         $this->assertArrayHasKey('bids', $data);

--- a/tests/SymbolTest.php
+++ b/tests/SymbolTest.php
@@ -98,7 +98,7 @@ class SymbolTest extends TestCase
      */
     public function testGetPartOrderBook(Symbol $api)
     {
-        $data = $api->getPartOrderBook('ETH-BTC');
+        $data = $api->getPartOrderBook('ETH-BTC', 100);
         $this->assertInternalType('array', $data);
         $this->assertArrayHasKey('sequence', $data);
         $this->assertArrayHasKey('bids', $data);


### PR DESCRIPTION
- Rename Account::getHistory to Account::getLedgers 
- Rename Deposit::getAddresses to Deposit::getAddress 
- Fix pagination of Deposit::getDeposits
- Fix parameters of Fill::getList
- Fix parameters of Symbol::getList
- Fix depth parameter of Symbol::getPartOrderBook
- Rename Symbol::getPartOrderBook to Symbol::getAggregatedPartOrderBook