### PR TITLE
allow relative paths in base uri

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -73,7 +73,7 @@ class Request
      */
     public function setBaseUri($baseUri)
     {
-        $this->baseUri = $baseUri ? rtrim($baseUri, '/') : null;
+        $this->baseUri = $baseUri ? sprintf('%s%s', rtrim($baseUri, '/'), '/') : null;
     }
 
     /**

--- a/src/PrivateApi/Account.php
+++ b/src/PrivateApi/Account.php
@@ -23,7 +23,7 @@ class Account extends KuCoinApi
      */
     public function create($type, $currency)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/accounts', compact('type', 'currency'));
+        $response = $this->call(Request::METHOD_POST, 'api/v1/accounts', compact('type', 'currency'));
         return $response->getApiData();
     }
 
@@ -37,7 +37,7 @@ class Account extends KuCoinApi
      */
     public function getList(array $params = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/accounts', $params);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/accounts', $params);
         return $response->getApiData();
     }
 
@@ -51,7 +51,7 @@ class Account extends KuCoinApi
      */
     public function getDetail($accountId)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/accounts/' . $accountId);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/accounts/' . $accountId);
         return $response->getApiData();
     }
 
@@ -69,7 +69,7 @@ class Account extends KuCoinApi
      */
     public function getLedgers($accountId, array $params = [], array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/accounts/' . $accountId . '/ledgers', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/accounts/' . $accountId . '/ledgers', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -84,7 +84,7 @@ class Account extends KuCoinApi
      */
     public function getHolds($accountId, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/accounts/' . $accountId . '/holds', $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/accounts/' . $accountId . '/holds', $pagination);
         return $response->getApiData();
     }
 
@@ -141,7 +141,7 @@ class Account extends KuCoinApi
      */
     public function getSubAccountUsers()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/sub/user');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/sub/user');
         return $response->getApiData();
     }
 
@@ -155,7 +155,7 @@ class Account extends KuCoinApi
      */
     public function getSubAccountDetail($subUserId)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/sub-accounts/' . $subUserId);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/sub-accounts/' . $subUserId);
         return $response->getApiData();
     }
 
@@ -168,7 +168,7 @@ class Account extends KuCoinApi
      */
     public function getSubAccountList()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/sub-accounts');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/sub-accounts');
         return $response->getApiData();
     }
 
@@ -183,7 +183,7 @@ class Account extends KuCoinApi
      */
     public function subTransfer(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/accounts/sub-transfer', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/accounts/sub-transfer', $params);
         return $response->getApiData();
     }
 
@@ -198,7 +198,7 @@ class Account extends KuCoinApi
      */
     public function subTransferV2(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v2/accounts/sub-transfer', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v2/accounts/sub-transfer', $params);
         return $response->getApiData();
     }
 
@@ -213,7 +213,7 @@ class Account extends KuCoinApi
      */
     public function getLedgersV2(array $params = [], array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/accounts/ledgers', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/accounts/ledgers', $params + $pagination);
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/Deposit.php
+++ b/src/PrivateApi/Deposit.php
@@ -23,7 +23,7 @@ class Deposit extends KuCoinApi
      */
     public function createAddress($currency, $chain = null)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/deposit-addresses', compact('currency', 'chain'));
+        $response = $this->call(Request::METHOD_POST, 'api/v1/deposit-addresses', compact('currency', 'chain'));
         return $response->getApiData();
     }
 
@@ -38,7 +38,7 @@ class Deposit extends KuCoinApi
      */
     public function getAddress($currency, $chain = null)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/deposit-addresses', compact('currency', 'chain'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/deposit-addresses', compact('currency', 'chain'));
         return $response->getApiData();
     }
 
@@ -54,7 +54,7 @@ class Deposit extends KuCoinApi
      */
     public function getAddresses($currency)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v2/deposit-addresses', compact('currency'));
+        $response = $this->call(Request::METHOD_GET, 'api/v2/deposit-addresses', compact('currency'));
         return $response->getApiData();
     }
 
@@ -69,7 +69,7 @@ class Deposit extends KuCoinApi
      */
     public function getDeposits(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/deposits', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/deposits', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -84,7 +84,7 @@ class Deposit extends KuCoinApi
      */
     public function getV1Deposits(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/hist-deposits', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/hist-deposits', $params + $pagination);
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/Fill.php
+++ b/src/PrivateApi/Fill.php
@@ -23,7 +23,7 @@ class Fill extends KuCoinApi
      */
     public function getList(array $params = [], array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/fills', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/fills', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -36,7 +36,7 @@ class Fill extends KuCoinApi
      */
     public function getRecentList()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/limit/fills');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/limit/fills');
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/Margin.php
+++ b/src/PrivateApi/Margin.php
@@ -39,7 +39,7 @@ class Margin extends KuCoinApi
      */
     public function getConfig()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/config');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/config');
         return $response->getApiData();
     }
 
@@ -54,7 +54,7 @@ class Margin extends KuCoinApi
      */
     public function getAccount()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/account');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/account');
         return $response->getApiData();
     }
 
@@ -69,7 +69,7 @@ class Margin extends KuCoinApi
      */
     public function borrow(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/margin/borrow', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/margin/borrow', $params);
         return $response->getApiData();
     }
 
@@ -84,7 +84,7 @@ class Margin extends KuCoinApi
      */
     public function getBorrow($orderId)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/borrow', compact('orderId'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/borrow', compact('orderId'));
         return $response->getApiData();
     }
 
@@ -99,7 +99,7 @@ class Margin extends KuCoinApi
      */
     public function getOutstanding($currency)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/borrow/outstanding', compact('currency'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/borrow/outstanding', compact('currency'));
         return $response->getApiData();
     }
 
@@ -114,7 +114,7 @@ class Margin extends KuCoinApi
      */
     public function getRepayRecord($currency)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/borrow/repaid', compact('currency'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/borrow/repaid', compact('currency'));
         return $response->getApiData();
     }
 
@@ -129,7 +129,7 @@ class Margin extends KuCoinApi
      */
     public function repayAll(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/margin/repay/all', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/margin/repay/all', $params);
         return $response->getApiData();
     }
 
@@ -144,7 +144,7 @@ class Margin extends KuCoinApi
      */
     public function repaySingle(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/margin/repay/single', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/margin/repay/single', $params);
         return $response->getApiData();
     }
 
@@ -159,7 +159,7 @@ class Margin extends KuCoinApi
      */
     public function lend(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/margin/lend', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/margin/lend', $params);
         return $response->getApiData();
     }
 
@@ -174,7 +174,7 @@ class Margin extends KuCoinApi
      */
     public function cancelLend($orderId)
     {
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/margin/lend/' . $orderId);
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/margin/lend/' . $orderId);
         return $response->getApiData();
     }
 
@@ -189,7 +189,7 @@ class Margin extends KuCoinApi
      */
     public function setAutoLend(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/margin/toggle-auto-lend', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/margin/toggle-auto-lend', $params);
         return $response->getApiData();
     }
 
@@ -205,7 +205,7 @@ class Margin extends KuCoinApi
      */
     public function getLendActive(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/lend/active', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/lend/active', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -221,7 +221,7 @@ class Margin extends KuCoinApi
      */
     public function getLendDone(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/lend/done', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/lend/done', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -237,7 +237,7 @@ class Margin extends KuCoinApi
      */
     public function getUnsettled(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/lend/trade/unsettled', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/lend/trade/unsettled', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -253,7 +253,7 @@ class Margin extends KuCoinApi
      */
     public function getSettled(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/lend/trade/settled', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/lend/trade/settled', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -268,7 +268,7 @@ class Margin extends KuCoinApi
      */
     public function getLendAssets($currency)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/lend/assets', compact('currency'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/lend/assets', compact('currency'));
         return $response->getApiData();
     }
 
@@ -283,7 +283,7 @@ class Margin extends KuCoinApi
      */
     public function getMarket(array $params)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/market', $params);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/market', $params);
         return $response->getApiData();
     }
 
@@ -298,7 +298,7 @@ class Margin extends KuCoinApi
      */
     public function getTradeLast($currency)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/margin/trade/last', compact('currency'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/margin/trade/last', compact('currency'));
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/Order.php
+++ b/src/PrivateApi/Order.php
@@ -23,7 +23,7 @@ class Order extends KuCoinApi
      */
     public function create(array $order)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/orders', $order);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/orders', $order);
         return $response->getApiData();
     }
 
@@ -38,7 +38,7 @@ class Order extends KuCoinApi
      */
     public function createMulti($symbol, array $orderList)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/orders/multi', compact('symbol', 'orderList'));
+        $response = $this->call(Request::METHOD_POST, 'api/v1/orders/multi', compact('symbol', 'orderList'));
         return $response->getApiData();
     }
 
@@ -52,7 +52,7 @@ class Order extends KuCoinApi
      */
     public function cancel($orderId)
     {
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/orders/' . $orderId);
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/orders/' . $orderId);
         return $response->getApiData();
     }
 
@@ -66,7 +66,7 @@ class Order extends KuCoinApi
      */
     public function cancelAll($symbol = null)
     {
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/orders', compact('symbol'));
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/orders', compact('symbol'));
         return $response->getApiData();
     }
 
@@ -81,7 +81,7 @@ class Order extends KuCoinApi
      */
     public function getList(array $params = [], array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/orders', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/orders', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -96,7 +96,7 @@ class Order extends KuCoinApi
      */
     public function getV1List(array $params = [], array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/hist-orders', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/hist-orders', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -110,7 +110,7 @@ class Order extends KuCoinApi
      */
     public function getDetail($orderId)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/orders/' . $orderId, []);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/orders/' . $orderId, []);
         return $response->getApiData();
     }
 
@@ -123,7 +123,7 @@ class Order extends KuCoinApi
      */
     public function getRecentList()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/limit/orders');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/limit/orders');
         return $response->getApiData();
     }
 
@@ -138,7 +138,7 @@ class Order extends KuCoinApi
      */
     public function getDetailByClientOid($clientOid)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/order/client-order/' . $clientOid, []);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/order/client-order/' . $clientOid, []);
         return $response->getApiData();
     }
 
@@ -153,7 +153,7 @@ class Order extends KuCoinApi
      */
     public function cancelByClientOid($clientOid)
     {
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/order/client-order/' . $clientOid);
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/order/client-order/' . $clientOid);
         return $response->getApiData();
     }
 
@@ -169,7 +169,7 @@ class Order extends KuCoinApi
      */
     public function createMarginOrder(array $order)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/margin/order', $order);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/margin/order', $order);
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/StopOrder.php
+++ b/src/PrivateApi/StopOrder.php
@@ -23,7 +23,7 @@ class StopOrder extends KuCoinApi
      */
     public function create(array $stopOrder)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/stop-order', $stopOrder);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/stop-order', $stopOrder);
         return $response->getApiData();
     }
 
@@ -37,7 +37,7 @@ class StopOrder extends KuCoinApi
      */
     public function cancelBatch(array $params)
     {
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/stop-order/cancel', $params);
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/stop-order/cancel', $params);
         return $response->getApiData();
     }
 
@@ -51,7 +51,7 @@ class StopOrder extends KuCoinApi
      */
     public function cancel($orderId)
     {
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/stop-order/' . $orderId);
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/stop-order/' . $orderId);
         return $response->getApiData();
     }
 
@@ -66,7 +66,7 @@ class StopOrder extends KuCoinApi
      */
     public function getList(array $params = [], array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/stop-order', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/stop-order', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -80,7 +80,7 @@ class StopOrder extends KuCoinApi
      */
     public function getDetail($orderId)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/stop-order/' . $orderId, []);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/stop-order/' . $orderId, []);
         return $response->getApiData();
     }
 
@@ -98,7 +98,7 @@ class StopOrder extends KuCoinApi
     public function getDetailByClientOid($clientOid, $symbol = null)
     {
         $params = compact('clientOid', 'symbol');
-        $response = $this->call(Request::METHOD_GET, '/api/v1/stop-order/queryOrderByClientOid', $params);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/stop-order/queryOrderByClientOid', $params);
         return $response->getApiData();
     }
 
@@ -114,7 +114,7 @@ class StopOrder extends KuCoinApi
     public function cancelByClientOid($clientOid, $symbol = null)
     {
         $params = compact('clientOid', 'symbol');
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/stop-order/cancelOrderByClientOid', $params);
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/stop-order/cancelOrderByClientOid', $params);
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/Symbol.php
+++ b/src/PrivateApi/Symbol.php
@@ -17,7 +17,7 @@ class Symbol extends KuCoinApi
      */
     public function getAggregatedFullOrderBook($symbol)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v3/market/orderbook/level2', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v3/market/orderbook/level2', compact('symbol'));
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/TradeFee.php
+++ b/src/PrivateApi/TradeFee.php
@@ -22,7 +22,7 @@ class TradeFee extends KuCoinApi
      */
     public function getBaseFee()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/base-fee');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/base-fee');
         return $response->getApiData();
     }
 
@@ -37,7 +37,7 @@ class TradeFee extends KuCoinApi
      */
     public function getTradeFees(array $symbols)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/trade-fees', ['symbols' => implode(',', $symbols)]);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/trade-fees', ['symbols' => implode(',', $symbols)]);
         return $response->getApiData();
     }
 }

--- a/src/PrivateApi/WebSocketFeed.php
+++ b/src/PrivateApi/WebSocketFeed.php
@@ -53,7 +53,7 @@ class WebSocketFeed extends KuCoinApi
      */
     public function getPublicBullet()
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/bullet-public');
+        $response = $this->call(Request::METHOD_POST, 'api/v1/bullet-public');
         return $response->getApiData();
     }
 
@@ -66,7 +66,7 @@ class WebSocketFeed extends KuCoinApi
      */
     public function getPrivateBullet()
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/bullet-private');
+        $response = $this->call(Request::METHOD_POST, 'api/v1/bullet-private');
         return $response->getApiData();
     }
 

--- a/src/PrivateApi/Withdrawal.php
+++ b/src/PrivateApi/Withdrawal.php
@@ -23,7 +23,7 @@ class Withdrawal extends KuCoinApi
      */
     public function getQuotas($currency, $chain = null)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/withdrawals/quotas', compact('currency', 'chain'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/withdrawals/quotas', compact('currency', 'chain'));
         return $response->getApiData();
     }
 
@@ -38,7 +38,7 @@ class Withdrawal extends KuCoinApi
      */
     public function getList(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/withdrawals', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/withdrawals', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -53,7 +53,7 @@ class Withdrawal extends KuCoinApi
      */
     public function getV1List(array $params, array $pagination = [])
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/hist-withdrawals', $params + $pagination);
+        $response = $this->call(Request::METHOD_GET, 'api/v1/hist-withdrawals', $params + $pagination);
         return $response->getApiData();
     }
 
@@ -67,7 +67,7 @@ class Withdrawal extends KuCoinApi
      */
     public function apply(array $params)
     {
-        $response = $this->call(Request::METHOD_POST, '/api/v1/withdrawals', $params);
+        $response = $this->call(Request::METHOD_POST, 'api/v1/withdrawals', $params);
         return $response->getApiData();
     }
 
@@ -81,7 +81,7 @@ class Withdrawal extends KuCoinApi
      */
     public function cancel($withdrawId)
     {
-        $response = $this->call(Request::METHOD_DELETE, '/api/v1/withdrawals/' . $withdrawId);
+        $response = $this->call(Request::METHOD_DELETE, 'api/v1/withdrawals/' . $withdrawId);
         return $response->getApiData();
     }
 }

--- a/src/PublicApi/Currency.php
+++ b/src/PublicApi/Currency.php
@@ -21,7 +21,7 @@ class Currency extends KuCoinApi
      */
     public function getList()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/currencies');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/currencies');
         return $response->getApiData();
     }
 
@@ -36,7 +36,7 @@ class Currency extends KuCoinApi
      */
     public function getDetail($currency, $chain = null)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/currencies/' . $currency, compact('chain'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/currencies/' . $currency, compact('chain'));
         return $response->getApiData();
     }
 
@@ -51,7 +51,7 @@ class Currency extends KuCoinApi
      */
     public function getPrices($base = null, $currencies = null)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/prices', compact('base', 'currencies'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/prices', compact('base', 'currencies'));
         return $response->getApiData();
     }
 
@@ -67,7 +67,7 @@ class Currency extends KuCoinApi
      */
     public function getV2Detail($currency, $chain = null)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v2/currencies/' . $currency, compact('chain'));
+        $response = $this->call(Request::METHOD_GET, 'api/v2/currencies/' . $currency, compact('chain'));
         return $response->getApiData();
     }
 }

--- a/src/PublicApi/ServiceStatus.php
+++ b/src/PublicApi/ServiceStatus.php
@@ -21,7 +21,7 @@ class ServiceStatus extends KuCoinApi
      */
     public function getStatus()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/status');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/status');
         return $response->getApiData();
     }
 }

--- a/src/PublicApi/Symbol.php
+++ b/src/PublicApi/Symbol.php
@@ -22,7 +22,7 @@ class Symbol extends KuCoinApi
      */
     public function getList($market = null)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/symbols', compact('market'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/symbols', compact('market'));
         return $response->getApiData();
     }
 
@@ -36,7 +36,7 @@ class Symbol extends KuCoinApi
      */
     public function getTicker($symbol)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/market/orderbook/level1', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/market/orderbook/level1', compact('symbol'));
         return $response->getApiData();
     }
 
@@ -49,7 +49,7 @@ class Symbol extends KuCoinApi
      */
     public function getAllTickers()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/market/allTickers');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/market/allTickers');
         return $response->getApiData();
     }
 
@@ -64,7 +64,7 @@ class Symbol extends KuCoinApi
      */
     public function getAggregatedPartOrderBook($symbol, $depth = 20)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/market/orderbook/level2_' . (int)$depth, compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/market/orderbook/level2_' . (int)$depth, compact('symbol'));
         return $response->getApiData();
     }
 
@@ -79,7 +79,7 @@ class Symbol extends KuCoinApi
      */
     public function getAggregatedFullOrderBook($symbol)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v2/market/orderbook/level2', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v2/market/orderbook/level2', compact('symbol'));
         return $response->getApiData();
     }
 
@@ -94,7 +94,7 @@ class Symbol extends KuCoinApi
      */
     public function getAtomicFullOrderBook($symbol)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/market/orderbook/level3', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/market/orderbook/level3', compact('symbol'));
         return $response->getApiData();
     }
 
@@ -109,7 +109,7 @@ class Symbol extends KuCoinApi
      */
     public function getV2AtomicFullOrderBook($symbol)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v2/market/orderbook/level3', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v2/market/orderbook/level3', compact('symbol'));
         return $response->getApiData();
     }
 
@@ -123,7 +123,7 @@ class Symbol extends KuCoinApi
      */
     public function getTradeHistories($symbol)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/market/histories', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/market/histories', compact('symbol'));
         return $response->getApiData();
     }
 
@@ -158,7 +158,7 @@ class Symbol extends KuCoinApi
      */
     public function get24HStats($symbol)
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/market/stats', compact('symbol'));
+        $response = $this->call(Request::METHOD_GET, 'api/v1/market/stats', compact('symbol'));
         return $response->getApiData();
     }
 
@@ -171,7 +171,7 @@ class Symbol extends KuCoinApi
      */
     public function getMarkets()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/markets');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/markets');
         return $response->getApiData();
     }
 }

--- a/src/PublicApi/Time.php
+++ b/src/PublicApi/Time.php
@@ -21,7 +21,7 @@ class Time extends KuCoinApi
      */
     public function timestamp()
     {
-        $response = $this->call(Request::METHOD_GET, '/api/v1/timestamp');
+        $response = $this->call(Request::METHOD_GET, 'api/v1/timestamp');
         return $response->getApiData();
     }
 }


### PR DESCRIPTION
We have a service which mocks responses from several exchanges at http://mocks/kucoin etc. Because the URI was hardcoded with a `/` prefix, Guzzle would always request http://mocks/api/v1/accounts instead of http://mocks/kucoin/api/v1/accounts, even with the base URL set to https://mocks/kucoin.

This PR allows setting the base URL to an url with a path